### PR TITLE
Code of conduct

### DIFF
--- a/CONDUCT.md
+++ b/CONDUCT.md
@@ -1,0 +1,20 @@
+### Contributor Code of Conduct
+
+As contributors and maintainers of this project, and in the interest of fostering an open and welcoming community, we pledge to respect all people who contribute through reporting issues, posting feature requests, updating documentation, submitting pull requests or patches, and other activities.
+
+We are committed to making participation in this project a harassment-free experience for everyone, regardless of level of experience, gender, gender identity and expression, sexual orientation, disability, personal appearance, body size, race, ethnicity, age, religion, or nationality.
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery
+* Personal attacks
+* Trolling or insulting/derogatory comments
+* Public or private harassment
+* Publishing other's private information, such as physical or electronic addresses, without explicit permission
+* Other unethical or unprofessional conduct.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, issues, and other contributions that are not aligned to this Code of Conduct. By adopting this Code of Conduct, project maintainers commit themselves to fairly and consistently applying these principles to every aspect of managing this project. Project maintainers who do not follow or enforce the Code of Conduct may be permanently removed from the project team.
+
+This code of conduct applies both within project spaces and in public spaces when an individual is representing the project or its community.
+
+This Code of Conduct is adapted from the [Cloud Native Computing Foundation (CNCF)](https://github.com/cncf/foundation) [code of conduct](https://github.com/cncf/foundation/edit/master/code-of-conduct.md).


### PR DESCRIPTION
I have created the code of conduct adapted from the [Cloud Native Computing Foundation (CNCF)](https://github.com/cncf/foundation) [code of conduct](https://github.com/cncf/foundation/edit/master/code-of-conduct.md). This will be consistent with our `CONTRIBUTING.md` which references the same code of conduct.